### PR TITLE
added invariant check for null data values

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "d3-scale": "^1.0.4",
     "d3-shape": "^1.0.4",
     "d3-voronoi": "^1.1.1",
+    "invariant": "^2.2.2",
     "lodash": "^4.17.4"
   },
   "devDependencies": {

--- a/src/Radar.js
+++ b/src/Radar.js
@@ -3,6 +3,7 @@ import React from 'react';
 import {schemeCategory10} from 'd3-scale';
 import {voronoi} from 'd3-voronoi';
 import _ from 'lodash';
+import invariant from 'invariant';
 import {
   flatMapDeepArray,
   forEachArray,
@@ -61,6 +62,9 @@ export default function Radar(props: Props) {
     onHover,
     highlighted,
   } = props;
+
+  invariant(data, 'The `data` property should be non-null.');
+
   const {allPoints, scales, offsetAngles, radius, voronoiDiagram} = convertData(
     props,
   );


### PR DESCRIPTION
## Why is this change necessary?

- If a falsy `data` prop is passed in to a `Radar` component then a deep React rendering error occurs.

## How does it address the issue?

- Adding `invariant` (for meaningful errors in non-`PRODUCTION` envs) to log if `data` is passed with a falsy value.

## What side effects does this change have?

- None

## How was it tested?

- Should pass test suite